### PR TITLE
Automatically create the class_extensions.json file when creating the folder

### DIFF
--- a/rules/validfolderpath.php
+++ b/rules/validfolderpath.php
@@ -56,7 +56,15 @@ class JFormRuleValidFolderPath extends FormRule
 				$file = $path . '/class_extensions.json';
 				touch($file);
 
-				File::write($file, '[]');
+				File::write($file, <<<JSON
+[
+  {
+    "class": "",
+    "file": ""
+  }
+]
+JSON
+				);
 
 				return true;
 			}

--- a/rules/validfolderpath.php
+++ b/rules/validfolderpath.php
@@ -57,13 +57,13 @@ class JFormRuleValidFolderPath extends FormRule
 				touch($file);
 
 				File::write($file, <<<JSON
-[
-  {
-    "class": "",
-    "file": ""
-  }
-]
-JSON
+					[
+					  {
+					    "class": "",
+					    "file": ""
+					  }
+					]
+					JSON
 				);
 
 				return true;

--- a/rules/validfolderpath.php
+++ b/rules/validfolderpath.php
@@ -10,9 +10,11 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Filesystem\File;
+use Joomla\CMS\Form\FormRule;
 use Joomla\CMS\Language\Text;
 
-class JFormRuleValidFolderPath extends \JFormRule
+class JFormRuleValidFolderPath extends FormRule
 {
 	public function test(SimpleXMLElement $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
 	{
@@ -51,6 +53,11 @@ class JFormRuleValidFolderPath extends \JFormRule
 		{
 			if (@mkdir($path, 0755, true))
 			{
+				$file = $path . '/class_extensions.json';
+				touch($file);
+
+				File::write($file, '[]');
+
 				return true;
 			}
 


### PR DESCRIPTION
This change automatically creates an `class_extensions.json` file for the end-user to fill. There is one empty entry to get the user started.