### PR TITLE
Make class extender application aware

### DIFF
--- a/classextender.php
+++ b/classextender.php
@@ -53,6 +53,14 @@ class plgSystemClassExtender extends CMSPlugin
      */
     private $extenderRootPath = '';
 
+	/**
+	 * Set if we are called for the site or administrator client
+	 *
+	 * @var    string
+	 * @since  1.0.0
+	 */
+	private $client = '';
+
     const EXTENSION = 'ExtensionBase';
 
 	public function __construct(&$subject, $config = array())
@@ -70,6 +78,8 @@ class plgSystemClassExtender extends CMSPlugin
 
 		// Remove amy leading and trailing slashes and prefix with website root.
 		$this->extenderRootPath = JPATH_ROOT . '/'. trim($this->extenderRootPath, '\\/');
+
+		$this->client = $this->app->getName();
 	}
 
 	/**
@@ -126,6 +136,14 @@ class plgSystemClassExtender extends CMSPlugin
 
     private function extend(\stdClass $extensionSpecs): void
     {
+		// Check if we need to verify the correct application client
+		if (isset($extensionSpecs->client)
+			&& !empty($extensionSpecs->client)
+			&& $extensionSpecs->client !== $this->client)
+		{
+			return;
+		}
+
         $className = $extensionSpecs->class;
 
         // Remove root path ...

--- a/rules/validfolderpath.php
+++ b/rules/validfolderpath.php
@@ -59,6 +59,7 @@ class JFormRuleValidFolderPath extends FormRule
 				File::write($file, <<<JSON
 					[
 					  {
+					    "client": "",
 					    "class": "",
 					    "file": ""
 					  }


### PR DESCRIPTION
This change makes the class extender application aware if needed by the user.

### Use-case
Overriding a class in HikaShop for the front-end conflicts with the same class name used in the backend.

I used this setup:
```
 {
    "class": "ProductViewProduct",
    "file": "components/com_hikashop/views/product/view.html.php",
    "dependencies": [
      "/administrator/components/com_hikashop/helpers/helper.php"
    ]
  }
```
This works fine looking at the front-end product listing for my changes. However going to the backend to see the product listing I get a fatal error `Call to a member function get() on array`. This happens because the front-end class is loaded instead of the back-end class.

Making the override application aware, we can load the class either for only front-end/back-end/cli or whichever client may come.

In the new case you get:
```
  {
    "client": "site",
    "class": "ProductViewProduct",
    "file": "components/com_hikashop/views/product/view.html.php",
    "dependencies": [
      "/administrator/components/com_hikashop/helpers/helper.php"
    ]
  }
```

P.s. this assumes the dependencies PR is already merged.
